### PR TITLE
PassLogger: Add a simplified constructor requiring only the name of the pass

### DIFF
--- a/src/PassLogger.cpp
+++ b/src/PassLogger.cpp
@@ -48,10 +48,15 @@ using namespace libpass;
 using namespace libstdhl;
 using namespace Memory;
 
-PassLogger::PassLogger( const PassInfo& info, libstdhl::Log::Stream& stream )
+PassLogger::PassLogger( const std::string& name, libstdhl::Log::Stream& stream )
 : Logger( stream )
 {
-    setSource( make< Log::Source >( info.name(), "Logging source of '" + info.name() + "'" ) );
+    setSource( make< Log::Source >( name, "Logging source of '" + name + "'" ) );
+}
+
+PassLogger::PassLogger( const PassInfo& info, libstdhl::Log::Stream& stream )
+: PassLogger( info.name(), stream )
+{
 }
 
 PassLogger::PassLogger( Pass::Id id, libstdhl::Log::Stream& stream )

--- a/src/PassLogger.h
+++ b/src/PassLogger.h
@@ -56,6 +56,8 @@ namespace libpass
     class PassLogger : public libstdhl::Logger
     {
       public:
+        PassLogger( const std::string& name, libstdhl::Log::Stream& stream );
+
         PassLogger( const PassInfo& info, libstdhl::Log::Stream& stream );
 
         PassLogger( Pass::Id id, libstdhl::Log::Stream& stream );


### PR DESCRIPTION
This simplifies the usage of the PassLogger in e.g. tests, because a PassLogger
can be created without having a PassManager and registered passes in place.